### PR TITLE
Implemented Grideye

### DIFF
--- a/occulow-firmware/occulow-firmware.cproj
+++ b/occulow-firmware/occulow-firmware.cproj
@@ -392,158 +392,158 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <ToolchainSettings>
       <ArmGcc>
-  <armgcc.common.outputfiles.hex>True</armgcc.common.outputfiles.hex>
-  <armgcc.common.outputfiles.lss>True</armgcc.common.outputfiles.lss>
-  <armgcc.common.outputfiles.eep>True</armgcc.common.outputfiles.eep>
-  <armgcc.common.outputfiles.bin>True</armgcc.common.outputfiles.bin>
-  <armgcc.common.outputfiles.srec>True</armgcc.common.outputfiles.srec>
-  <armgcc.compiler.symbols.DefSymbols>
-    <ListValues>
-      <Value>DEBUG</Value>
-      <Value>BOARD=USER_BOARD</Value>
-      <Value>ARM_MATH_CM0PLUS=true</Value>
-      <Value>EXTINT_CALLBACK_MODE=true</Value>
-      <Value>I2C_MASTER_CALLBACK_MODE=false</Value>
-      <Value>USART_CALLBACK_MODE=false</Value>
-      <Value>SYSTICK_MODE</Value>
-    </ListValues>
-  </armgcc.compiler.symbols.DefSymbols>
-  <armgcc.compiler.directories.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/sam0/utils</Value>
-      <Value>../src/ASF/sam0/utils/header_files</Value>
-      <Value>../src/ASF/sam0/utils/preprocessor</Value>
-      <Value>../src/ASF/thirdparty/CMSIS/Include</Value>
-      <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src/ASF/sam0/utils/cmsis/saml21/include_b</Value>
-      <Value>../src/ASF/sam0/utils/cmsis/saml21/source</Value>
-      <Value>../src/ASF/sam0/drivers/system</Value>
-      <Value>../src/ASF/sam0/drivers/system/clock/clock_saml21</Value>
-      <Value>../src/ASF/sam0/drivers/system/clock</Value>
-      <Value>../src/ASF/sam0/drivers/system/interrupt</Value>
-      <Value>../src/ASF/sam0/drivers/system/interrupt/system_interrupt_saml21</Value>
-      <Value>../src/ASF/sam0/drivers/system/pinmux</Value>
-      <Value>../src/ASF/sam0/drivers/system/power/power_sam_l</Value>
-      <Value>../src/ASF/sam0/drivers/system/power</Value>
-      <Value>../src/ASF/sam0/drivers/system/reset/reset_sam_l</Value>
-      <Value>../src/ASF/sam0/drivers/system/reset</Value>
-      <Value>../src/ASF/common2/boards/user_board</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/ASF/sam0/utils/stdio/stdio_serial</Value>
-      <Value>../src/ASF/common/services/serial</Value>
-      <Value>../src/ASF/sam0/drivers/extint</Value>
-      <Value>../src/ASF/sam0/drivers/extint/extint_sam_l_c</Value>
-      <Value>../src/ASF/sam0/drivers/sercom</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/i2c</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/i2c/i2c_sam0</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/usart</Value>
-      <Value>../src/ASF/sam0/drivers/port</Value>
-      <Value>../src/ASF/common2/services/delay</Value>
-      <Value>../src/ASF/common2/services/delay/sam0</Value>
-    </ListValues>
-  </armgcc.compiler.directories.IncludePaths>
-  <armgcc.compiler.optimization.level>Optimize (-O1)</armgcc.compiler.optimization.level>
-  <armgcc.compiler.optimization.OtherFlags>-fdata-sections</armgcc.compiler.optimization.OtherFlags>
-  <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
-  <armgcc.compiler.optimization.DebugLevel>Maximum (-g3)</armgcc.compiler.optimization.DebugLevel>
-  <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
-  <armgcc.compiler.miscellaneous.OtherFlags>-pipe -fno-strict-aliasing -Wall -Wstrict-prototypes -Wmissing-prototypes -Werror-implicit-function-declaration -Wpointer-arith -std=gnu99 -ffunction-sections -fdata-sections -Wchar-subscripts -Wcomment -Wformat=2 -Wimplicit-int -Wmain -Wparentheses -Wsequence-point -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wuninitialized -Wunknown-pragmas -Wfloat-equal -Wundef -Wshadow -Wbad-function-cast -Wwrite-strings -Wsign-compare -Waggregate-return  -Wmissing-declarations -Wformat -Wmissing-format-attribute -Wno-deprecated-declarations -Wpacked -Wredundant-decls -Wnested-externs -Wlong-long -Wunreachable-code -Wcast-align --param max-inline-insns-single=500</armgcc.compiler.miscellaneous.OtherFlags>
-  <armgcc.linker.general.UseNewlibNano>True</armgcc.linker.general.UseNewlibNano>
-  <armgcc.linker.libraries.Libraries>
-    <ListValues>
-      <Value>libarm_cortexM0l_math</Value>
-      <Value>libm</Value>
-    </ListValues>
-  </armgcc.linker.libraries.Libraries>
-  <armgcc.linker.libraries.LibrarySearchPaths>
-    <ListValues>
-      <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
-    </ListValues>
-  </armgcc.linker.libraries.LibrarySearchPaths>
-  <armgcc.linker.optimization.GarbageCollectUnusedSections>True</armgcc.linker.optimization.GarbageCollectUnusedSections>
-  <armgcc.linker.memorysettings.ExternalRAM />
-  <armgcc.linker.miscellaneous.LinkerFlags>-Wl,--entry=Reset_Handler -Wl,--cref -mthumb -T../src/ASF/sam0/utils/linker_scripts/saml21/gcc/saml21e18b_flash.ld</armgcc.linker.miscellaneous.LinkerFlags>
-  <armgcc.assembler.general.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/sam0/utils</Value>
-      <Value>../src/ASF/sam0/utils/header_files</Value>
-      <Value>../src/ASF/sam0/utils/preprocessor</Value>
-      <Value>../src/ASF/thirdparty/CMSIS/Include</Value>
-      <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src/ASF/sam0/utils/cmsis/saml21/include_b</Value>
-      <Value>../src/ASF/sam0/utils/cmsis/saml21/source</Value>
-      <Value>../src/ASF/sam0/drivers/system</Value>
-      <Value>../src/ASF/sam0/drivers/system/clock/clock_saml21</Value>
-      <Value>../src/ASF/sam0/drivers/system/clock</Value>
-      <Value>../src/ASF/sam0/drivers/system/interrupt</Value>
-      <Value>../src/ASF/sam0/drivers/system/interrupt/system_interrupt_saml21</Value>
-      <Value>../src/ASF/sam0/drivers/system/pinmux</Value>
-      <Value>../src/ASF/sam0/drivers/system/power/power_sam_l</Value>
-      <Value>../src/ASF/sam0/drivers/system/power</Value>
-      <Value>../src/ASF/sam0/drivers/system/reset/reset_sam_l</Value>
-      <Value>../src/ASF/sam0/drivers/system/reset</Value>
-      <Value>../src/ASF/common2/boards/user_board</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/ASF/sam0/utils/stdio/stdio_serial</Value>
-      <Value>../src/ASF/common/services/serial</Value>
-      <Value>../src/ASF/sam0/drivers/extint</Value>
-      <Value>../src/ASF/sam0/drivers/extint/extint_sam_l_c</Value>
-      <Value>../src/ASF/sam0/drivers/sercom</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/i2c</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/i2c/i2c_sam0</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/usart</Value>
-      <Value>../src/ASF/sam0/drivers/port</Value>
-      <Value>../src/ASF/common2/services/delay</Value>
-      <Value>../src/ASF/common2/services/delay/sam0</Value>
-    </ListValues>
-  </armgcc.assembler.general.IncludePaths>
-  <armgcc.assembler.debugging.DebugLevel>Default (-g)</armgcc.assembler.debugging.DebugLevel>
-  <armgcc.preprocessingassembler.general.AssemblerFlags>-DARM_MATH_CM0PLUS=true -DBOARD=USER_BOARD -DEXTINT_CALLBACK_MODE=true -DI2C_MASTER_CALLBACK_MODE=false -DUSART_CALLBACK_MODE=false -DSYSTICK_MODE</armgcc.preprocessingassembler.general.AssemblerFlags>
-  <armgcc.preprocessingassembler.general.IncludePaths>
-    <ListValues>
-      <Value>../src/ASF/common/boards</Value>
-      <Value>../src/ASF/sam0/utils</Value>
-      <Value>../src/ASF/sam0/utils/header_files</Value>
-      <Value>../src/ASF/sam0/utils/preprocessor</Value>
-      <Value>../src/ASF/thirdparty/CMSIS/Include</Value>
-      <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
-      <Value>../src/ASF/common/utils</Value>
-      <Value>../src/ASF/sam0/utils/cmsis/saml21/include_b</Value>
-      <Value>../src/ASF/sam0/utils/cmsis/saml21/source</Value>
-      <Value>../src/ASF/sam0/drivers/system</Value>
-      <Value>../src/ASF/sam0/drivers/system/clock/clock_saml21</Value>
-      <Value>../src/ASF/sam0/drivers/system/clock</Value>
-      <Value>../src/ASF/sam0/drivers/system/interrupt</Value>
-      <Value>../src/ASF/sam0/drivers/system/interrupt/system_interrupt_saml21</Value>
-      <Value>../src/ASF/sam0/drivers/system/pinmux</Value>
-      <Value>../src/ASF/sam0/drivers/system/power/power_sam_l</Value>
-      <Value>../src/ASF/sam0/drivers/system/power</Value>
-      <Value>../src/ASF/sam0/drivers/system/reset/reset_sam_l</Value>
-      <Value>../src/ASF/sam0/drivers/system/reset</Value>
-      <Value>../src/ASF/common2/boards/user_board</Value>
-      <Value>../src</Value>
-      <Value>../src/config</Value>
-      <Value>../src/ASF/sam0/utils/stdio/stdio_serial</Value>
-      <Value>../src/ASF/common/services/serial</Value>
-      <Value>../src/ASF/sam0/drivers/extint</Value>
-      <Value>../src/ASF/sam0/drivers/extint/extint_sam_l_c</Value>
-      <Value>../src/ASF/sam0/drivers/sercom</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/i2c</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/i2c/i2c_sam0</Value>
-      <Value>../src/ASF/sam0/drivers/sercom/usart</Value>
-      <Value>../src/ASF/sam0/drivers/port</Value>
-      <Value>../src/ASF/common2/services/delay</Value>
-      <Value>../src/ASF/common2/services/delay/sam0</Value>
-    </ListValues>
-  </armgcc.preprocessingassembler.general.IncludePaths>
-  <armgcc.preprocessingassembler.debugging.DebugLevel>Default (-Wa,-g)</armgcc.preprocessingassembler.debugging.DebugLevel>
-</ArmGcc>
+        <armgcc.common.outputfiles.hex>True</armgcc.common.outputfiles.hex>
+        <armgcc.common.outputfiles.lss>True</armgcc.common.outputfiles.lss>
+        <armgcc.common.outputfiles.eep>True</armgcc.common.outputfiles.eep>
+        <armgcc.common.outputfiles.bin>True</armgcc.common.outputfiles.bin>
+        <armgcc.common.outputfiles.srec>True</armgcc.common.outputfiles.srec>
+        <armgcc.compiler.symbols.DefSymbols>
+          <ListValues>
+            <Value>DEBUG</Value>
+            <Value>BOARD=USER_BOARD</Value>
+            <Value>ARM_MATH_CM0PLUS=true</Value>
+            <Value>EXTINT_CALLBACK_MODE=true</Value>
+            <Value>I2C_MASTER_CALLBACK_MODE=false</Value>
+            <Value>USART_CALLBACK_MODE=false</Value>
+            <Value>SYSTICK_MODE</Value>
+          </ListValues>
+        </armgcc.compiler.symbols.DefSymbols>
+        <armgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/sam0/utils</Value>
+            <Value>../src/ASF/sam0/utils/header_files</Value>
+            <Value>../src/ASF/sam0/utils/preprocessor</Value>
+            <Value>../src/ASF/thirdparty/CMSIS/Include</Value>
+            <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src/ASF/sam0/utils/cmsis/saml21/include_b</Value>
+            <Value>../src/ASF/sam0/utils/cmsis/saml21/source</Value>
+            <Value>../src/ASF/sam0/drivers/system</Value>
+            <Value>../src/ASF/sam0/drivers/system/clock/clock_saml21</Value>
+            <Value>../src/ASF/sam0/drivers/system/clock</Value>
+            <Value>../src/ASF/sam0/drivers/system/interrupt</Value>
+            <Value>../src/ASF/sam0/drivers/system/interrupt/system_interrupt_saml21</Value>
+            <Value>../src/ASF/sam0/drivers/system/pinmux</Value>
+            <Value>../src/ASF/sam0/drivers/system/power/power_sam_l</Value>
+            <Value>../src/ASF/sam0/drivers/system/power</Value>
+            <Value>../src/ASF/sam0/drivers/system/reset/reset_sam_l</Value>
+            <Value>../src/ASF/sam0/drivers/system/reset</Value>
+            <Value>../src/ASF/common2/boards/user_board</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/ASF/sam0/utils/stdio/stdio_serial</Value>
+            <Value>../src/ASF/common/services/serial</Value>
+            <Value>../src/ASF/sam0/drivers/extint</Value>
+            <Value>../src/ASF/sam0/drivers/extint/extint_sam_l_c</Value>
+            <Value>../src/ASF/sam0/drivers/sercom</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/i2c</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/i2c/i2c_sam0</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/usart</Value>
+            <Value>../src/ASF/sam0/drivers/port</Value>
+            <Value>../src/ASF/common2/services/delay</Value>
+            <Value>../src/ASF/common2/services/delay/sam0</Value>
+          </ListValues>
+        </armgcc.compiler.directories.IncludePaths>
+        <armgcc.compiler.optimization.level>Optimize (-O1)</armgcc.compiler.optimization.level>
+        <armgcc.compiler.optimization.OtherFlags>-fdata-sections</armgcc.compiler.optimization.OtherFlags>
+        <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
+        <armgcc.compiler.optimization.DebugLevel>Maximum (-g3)</armgcc.compiler.optimization.DebugLevel>
+        <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
+        <armgcc.compiler.miscellaneous.OtherFlags>-pipe -fno-strict-aliasing -Wall -Wstrict-prototypes -Wmissing-prototypes -Werror-implicit-function-declaration -Wpointer-arith -std=gnu99 -ffunction-sections -fdata-sections -Wchar-subscripts -Wcomment -Wformat=2 -Wimplicit-int -Wmain -Wparentheses -Wsequence-point -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wuninitialized -Wunknown-pragmas -Wfloat-equal -Wundef -Wshadow -Wbad-function-cast -Wwrite-strings -Wsign-compare -Waggregate-return  -Wmissing-declarations -Wformat -Wmissing-format-attribute -Wno-deprecated-declarations -Wpacked -Wredundant-decls -Wnested-externs -Wlong-long -Wunreachable-code -Wcast-align --param max-inline-insns-single=500</armgcc.compiler.miscellaneous.OtherFlags>
+        <armgcc.linker.general.UseNewlibNano>True</armgcc.linker.general.UseNewlibNano>
+        <armgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>libarm_cortexM0l_math</Value>
+            <Value>libm</Value>
+          </ListValues>
+        </armgcc.linker.libraries.Libraries>
+        <armgcc.linker.libraries.LibrarySearchPaths>
+          <ListValues>
+            <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
+          </ListValues>
+        </armgcc.linker.libraries.LibrarySearchPaths>
+        <armgcc.linker.optimization.GarbageCollectUnusedSections>True</armgcc.linker.optimization.GarbageCollectUnusedSections>
+        <armgcc.linker.memorysettings.ExternalRAM />
+        <armgcc.linker.miscellaneous.LinkerFlags>-Wl,--entry=Reset_Handler -Wl,--cref -mthumb -T../src/ASF/sam0/utils/linker_scripts/saml21/gcc/saml21e18b_flash.ld</armgcc.linker.miscellaneous.LinkerFlags>
+        <armgcc.assembler.general.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/sam0/utils</Value>
+            <Value>../src/ASF/sam0/utils/header_files</Value>
+            <Value>../src/ASF/sam0/utils/preprocessor</Value>
+            <Value>../src/ASF/thirdparty/CMSIS/Include</Value>
+            <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src/ASF/sam0/utils/cmsis/saml21/include_b</Value>
+            <Value>../src/ASF/sam0/utils/cmsis/saml21/source</Value>
+            <Value>../src/ASF/sam0/drivers/system</Value>
+            <Value>../src/ASF/sam0/drivers/system/clock/clock_saml21</Value>
+            <Value>../src/ASF/sam0/drivers/system/clock</Value>
+            <Value>../src/ASF/sam0/drivers/system/interrupt</Value>
+            <Value>../src/ASF/sam0/drivers/system/interrupt/system_interrupt_saml21</Value>
+            <Value>../src/ASF/sam0/drivers/system/pinmux</Value>
+            <Value>../src/ASF/sam0/drivers/system/power/power_sam_l</Value>
+            <Value>../src/ASF/sam0/drivers/system/power</Value>
+            <Value>../src/ASF/sam0/drivers/system/reset/reset_sam_l</Value>
+            <Value>../src/ASF/sam0/drivers/system/reset</Value>
+            <Value>../src/ASF/common2/boards/user_board</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/ASF/sam0/utils/stdio/stdio_serial</Value>
+            <Value>../src/ASF/common/services/serial</Value>
+            <Value>../src/ASF/sam0/drivers/extint</Value>
+            <Value>../src/ASF/sam0/drivers/extint/extint_sam_l_c</Value>
+            <Value>../src/ASF/sam0/drivers/sercom</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/i2c</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/i2c/i2c_sam0</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/usart</Value>
+            <Value>../src/ASF/sam0/drivers/port</Value>
+            <Value>../src/ASF/common2/services/delay</Value>
+            <Value>../src/ASF/common2/services/delay/sam0</Value>
+          </ListValues>
+        </armgcc.assembler.general.IncludePaths>
+        <armgcc.assembler.debugging.DebugLevel>Default (-g)</armgcc.assembler.debugging.DebugLevel>
+        <armgcc.preprocessingassembler.general.AssemblerFlags>-DARM_MATH_CM0PLUS=true -DBOARD=USER_BOARD -DEXTINT_CALLBACK_MODE=true -DI2C_MASTER_CALLBACK_MODE=false -DUSART_CALLBACK_MODE=false -DSYSTICK_MODE</armgcc.preprocessingassembler.general.AssemblerFlags>
+        <armgcc.preprocessingassembler.general.IncludePaths>
+          <ListValues>
+            <Value>../src/ASF/common/boards</Value>
+            <Value>../src/ASF/sam0/utils</Value>
+            <Value>../src/ASF/sam0/utils/header_files</Value>
+            <Value>../src/ASF/sam0/utils/preprocessor</Value>
+            <Value>../src/ASF/thirdparty/CMSIS/Include</Value>
+            <Value>../src/ASF/thirdparty/CMSIS/Lib/GCC</Value>
+            <Value>../src/ASF/common/utils</Value>
+            <Value>../src/ASF/sam0/utils/cmsis/saml21/include_b</Value>
+            <Value>../src/ASF/sam0/utils/cmsis/saml21/source</Value>
+            <Value>../src/ASF/sam0/drivers/system</Value>
+            <Value>../src/ASF/sam0/drivers/system/clock/clock_saml21</Value>
+            <Value>../src/ASF/sam0/drivers/system/clock</Value>
+            <Value>../src/ASF/sam0/drivers/system/interrupt</Value>
+            <Value>../src/ASF/sam0/drivers/system/interrupt/system_interrupt_saml21</Value>
+            <Value>../src/ASF/sam0/drivers/system/pinmux</Value>
+            <Value>../src/ASF/sam0/drivers/system/power/power_sam_l</Value>
+            <Value>../src/ASF/sam0/drivers/system/power</Value>
+            <Value>../src/ASF/sam0/drivers/system/reset/reset_sam_l</Value>
+            <Value>../src/ASF/sam0/drivers/system/reset</Value>
+            <Value>../src/ASF/common2/boards/user_board</Value>
+            <Value>../src</Value>
+            <Value>../src/config</Value>
+            <Value>../src/ASF/sam0/utils/stdio/stdio_serial</Value>
+            <Value>../src/ASF/common/services/serial</Value>
+            <Value>../src/ASF/sam0/drivers/extint</Value>
+            <Value>../src/ASF/sam0/drivers/extint/extint_sam_l_c</Value>
+            <Value>../src/ASF/sam0/drivers/sercom</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/i2c</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/i2c/i2c_sam0</Value>
+            <Value>../src/ASF/sam0/drivers/sercom/usart</Value>
+            <Value>../src/ASF/sam0/drivers/port</Value>
+            <Value>../src/ASF/common2/services/delay</Value>
+            <Value>../src/ASF/common2/services/delay/sam0</Value>
+          </ListValues>
+        </armgcc.preprocessingassembler.general.IncludePaths>
+        <armgcc.preprocessingassembler.debugging.DebugLevel>Default (-Wa,-g)</armgcc.preprocessingassembler.debugging.DebugLevel>
+      </ArmGcc>
     </ToolchainSettings>
   </PropertyGroup>
   <ItemGroup>
@@ -613,6 +613,7 @@
     <Folder Include="src\ASF\thirdparty\CMSIS\Lib\GCC\" />
     <Folder Include="src\config\" />
     <Folder Include="src\drivers" />
+    <Folder Include="src\drivers\grideye" />
     <Folder Include="src\drivers\pir" />
   </ItemGroup>
   <ItemGroup>
@@ -1117,6 +1118,12 @@
     <None Include="src\config\conf_extint.h">
       <SubType>compile</SubType>
     </None>
+    <Compile Include="src\drivers\grideye\grideye.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="src\drivers\grideye\grideye.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="src\drivers\pir\pir.c">
       <SubType>compile</SubType>
     </Compile>

--- a/occulow-firmware/src/drivers/grideye/grideye.c
+++ b/occulow-firmware/src/drivers/grideye/grideye.c
@@ -1,0 +1,196 @@
+/*
+* grideye.c
+*
+* Created: 3/1/2017 8:28:44 PM
+*  Author: Terence Sun (tsun1215)
+*/
+
+#include <asf.h>
+#include <drivers/grideye/grideye.h>
+
+#define GE_BUFFER_DATA_LENGTH 128
+static uint8_t ge_write_buffer[GE_BUFFER_DATA_LENGTH];
+static uint8_t ge_read_buffer[GE_BUFFER_DATA_LENGTH];
+static uint8_t ge_mode = GE_MODE_NORMAL;
+
+#define GE_SLAVE_ADDRESS 0x68
+#define GE_REG_THERM_LSB 0x0E
+#define GE_REG_THERM_MSB 0x0F
+#define GE_REG_PIXEL_BASE 0x80
+#define GE_REG_STATE 0x00
+#define GE_REG_RESET 0x01
+
+#define GE_CMD_INITIAL_RESET 0x3F
+#define GE_CMD_FLAG_RESET 0x30
+
+/* Number of times to try to send packet if failed. */
+#define TIMEOUT 1000
+
+/* Init software module. */
+struct i2c_master_module i2c_master_instance;
+
+uint8_t read_byte(uint8_t addr);
+void write_byte(uint8_t addr, uint8_t *data, uint8_t length);
+
+void grideye_init(void)
+{
+	/* Initialize config structure and software module. */
+	struct i2c_master_config config_i2c_master;
+	i2c_master_get_config_defaults(&config_i2c_master);
+
+	/* Change buffer timeout to something longer. */
+	config_i2c_master.buffer_timeout = 10000;
+	
+	/* Initialize and enable device with config. */
+	i2c_master_init(&i2c_master_instance, GE_I2C_SERCOM, &config_i2c_master);
+
+	i2c_master_enable(&i2c_master_instance);
+}
+
+/**
+ * @brief      Returns whether or not the grideye is sleeping
+ *
+ * @return     True if the grideye is sleeping, false otherwise
+ */
+bool ge_is_sleeping(void) {
+	return ge_mode == GE_MODE_SLEEP;
+}
+
+/**
+ * @brief      Sets the mode of the grideye
+ *
+ * @param[in]  mode  The mode
+ *
+ * @return     True if the mode was valid, false otherwise
+ */
+bool ge_set_mode(uint8_t mode) {
+	if (ge_mode == mode) {
+		return false;  // Already in this mode
+	}
+	if (ge_mode != GE_MODE_NORMAL) {
+		if (mode != GE_MODE_NORMAL) {
+			return false;  // Other modes can only transition to normal state
+		}
+	}
+	write_byte(GE_REG_STATE, &mode, 1);
+
+	if (ge_mode == GE_MODE_SLEEP) {  // This must be a wakeup command
+		uint8_t rst_cmd;
+		// Wait 50ms
+		delay_ms(50);
+		// Write inital reset
+		rst_cmd = GE_CMD_INITIAL_RESET;
+		write_byte(GE_REG_RESET, &rst_cmd, 1);
+		// Wait 2ms
+		delay_ms(2);
+		// Write flag reset
+		rst_cmd = GE_CMD_FLAG_RESET;
+		write_byte(GE_REG_RESET, &rst_cmd, 1);
+		// Wait 2 frames
+		delay_ms(200);
+	}
+	ge_mode = mode;
+	return true;
+}
+
+/**
+ * @brief      Gets ambient temperature in Celsius
+ *
+ * @return     Ambient temperature from the grideye sensor
+ */
+double ge_get_ambient_temp(void)
+{
+	uint8_t lsb, msb;
+
+	lsb = read_byte(GE_REG_THERM_LSB);
+	msb = read_byte(GE_REG_THERM_MSB);
+	return (((msb << 8) + lsb) * 0.0625);
+}
+
+/**
+ * @brief      Gets a frame from the GridEye
+ *
+ * @param      frame_buffer  Buffer to read frames into
+ */
+void ge_get_frame(uint16_t *frame_buffer)
+{
+	uint8_t lsb, msb;
+	for (int i = 0; i < NUM_PIXELS; i++) {
+		lsb = read_byte(GE_REG_PIXEL_BASE + 2*i);
+		msb = read_byte(GE_REG_PIXEL_BASE + 2*i + 1);
+		frame_buffer[i] = ((msb << 8) + lsb);
+		// Convert to Celcius (temp = raw * 0.25)
+		// frame_buffer[i] = (((msb << 8) + lsb) * 0.25);
+	}
+}
+
+/**
+ * @brief      Reads a byte via I2C.
+ *
+ * @param[in]  addr  Address to read from
+ *
+ * @return     Value read from the address
+ */
+uint8_t read_byte(uint8_t addr) {
+	uint16_t timeout = 0;
+	struct i2c_master_packet packet = {
+		.address = GE_SLAVE_ADDRESS,
+		.data_length = 1,
+		.ten_bit_address = false,
+		.high_speed = false,
+		.hs_master_code = 0x0,
+	};
+	
+	/* Write addr to read */
+	ge_write_buffer[0] = addr;
+	packet.data = ge_write_buffer;
+	while (i2c_master_write_packet_wait(&i2c_master_instance, &packet) != STATUS_OK) {
+		/* Increment timeout counter and check if timed out. */
+		if (timeout++ == TIMEOUT) {
+			break;
+		}
+	}
+	
+	/* Read value */
+	packet.data = ge_read_buffer;
+	while (i2c_master_read_packet_wait(&i2c_master_instance, &packet) !=
+	STATUS_OK) {
+		/* Increment timeout counter and check if timed out. */
+		if (timeout++ == TIMEOUT) {
+			break;
+		}
+	}
+	
+	return ge_read_buffer[0];
+}
+
+/**
+ * @brief      Writes bytes to the given address
+ *
+ * @param[in]  addr    Address to write to
+ * @param      data    Data to write
+ * @param[in]  length  Length of data
+ */
+void write_byte(uint8_t addr, uint8_t *data, uint8_t length) {
+	uint16_t timeout = 0;
+	struct i2c_master_packet packet = {
+		.address = GE_SLAVE_ADDRESS,
+		.data_length = length + 1,
+		.ten_bit_address = false,
+		.high_speed = false,
+		.hs_master_code = 0x0,
+	};
+
+	// Populate write buffer [addr, <data>...]
+	ge_write_buffer[0] = addr;
+	for (uint8_t i = 0; i < length; i++) {
+		ge_write_buffer[i+1] = data[i];
+	}
+	packet.data = ge_write_buffer;
+	while (i2c_master_write_packet_wait(&i2c_master_instance, &packet) != STATUS_OK) {
+		/* Increment timeout counter and check if timed out. */
+		if (timeout++ == TIMEOUT) {
+			break;
+		}
+	}
+}

--- a/occulow-firmware/src/drivers/grideye/grideye.c
+++ b/occulow-firmware/src/drivers/grideye/grideye.c
@@ -39,11 +39,12 @@ void grideye_init(void)
 	i2c_master_get_config_defaults(&config_i2c_master);
 
 	/* Change buffer timeout to something longer. */
-	config_i2c_master.buffer_timeout = 10000;
+	config_i2c_master.buffer_timeout = GE_I2C_BUFFER_TIMEOUT;
+	config_i2c_master.pinmux_pad0 = GE_SERCOM_PAD0;
+	config_i2c_master.pinmux_pad1 = GE_SERCOM_PAD1;
 	
 	/* Initialize and enable device with config. */
-	i2c_master_init(&i2c_master_instance, GE_I2C_SERCOM, &config_i2c_master);
-
+	i2c_master_init(&i2c_master_instance, GE_I2C_MODULE, &config_i2c_master);
 	i2c_master_enable(&i2c_master_instance);
 }
 
@@ -152,6 +153,7 @@ uint8_t read_byte(uint8_t addr) {
 	}
 	
 	/* Read value */
+	timeout = 0;
 	packet.data = ge_read_buffer;
 	while (i2c_master_read_packet_wait(&i2c_master_instance, &packet) !=
 	STATUS_OK) {

--- a/occulow-firmware/src/drivers/grideye/grideye.h
+++ b/occulow-firmware/src/drivers/grideye/grideye.h
@@ -1,0 +1,25 @@
+/*
+ * grideye.h
+ *
+ * Created: 3/1/2017 8:54:53 PM
+ *  Author: Terence Sun (tsun1215)
+ */ 
+
+#ifndef GRIDEYE_H_
+#define GRIDEYE_H_
+
+#define NUM_PIXELS 64
+#define GE_MODE_NORMAL 0x00
+#define GE_MODE_SLEEP 0x10
+#define GE_MODE_STANDBY_1 0x20
+#define GE_MODE_STANDBY_2 0x21
+
+#define GE_I2C_SERCOM SERCOM2
+
+void grideye_init(void);
+bool ge_is_sleeping(void);
+bool ge_set_mode(uint8_t mode);
+double ge_get_ambient_temp(void);
+void ge_get_frame(uint16_t *frame_buffer);
+
+#endif /* GRIDEYE_H_ */

--- a/occulow-firmware/src/drivers/grideye/grideye.h
+++ b/occulow-firmware/src/drivers/grideye/grideye.h
@@ -14,7 +14,10 @@
 #define GE_MODE_STANDBY_1 0x20
 #define GE_MODE_STANDBY_2 0x21
 
-#define GE_I2C_SERCOM SERCOM2
+#define GE_I2C_BUFFER_TIMEOUT 10000
+#define GE_I2C_MODULE SERCOM3
+#define GE_SERCOM_PAD0 PINMUX_PA00D_SERCOM1_PAD0
+#define GE_SERCOM_PAD1 PINMUX_PA01D_SERCOM1_PAD1
 
 void grideye_init(void);
 bool ge_is_sleeping(void);

--- a/occulow-firmware/src/main.c
+++ b/occulow-firmware/src/main.c
@@ -1,32 +1,8 @@
 /**
- * \file
- *
- * \brief Empty user application template
+ * main.c
  *
  */
 
-/**
- * \mainpage User Application template doxygen documentation
- *
- * \par Empty user application template
- *
- * Bare minimum empty user application template
- *
- * \par Content
- *
- * -# Include the ASF header files (through asf.h)
- * -# Minimal main function that starts with a call to system_init()
- * -# "Insert application code here" comment
- *
- */
-
-/*
- * Include header files for all drivers that have been imported from
- * Atmel Software Framework (ASF).
- */
-/*
- * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
- */
 #include <asf.h>
 #include <drivers/pir/pir.h>
 #include <drivers/grideye/grideye.h>

--- a/occulow-firmware/src/main.c
+++ b/occulow-firmware/src/main.c
@@ -29,6 +29,7 @@
  */
 #include <asf.h>
 #include <drivers/pir/pir.h>
+#include <drivers/grideye/grideye.h>
 
 /**
  * @brief      Runs when the PIR detects motion
@@ -41,9 +42,15 @@ void pir_on_wake(void) {
 
 int main (void)
 {
+	uint16_t grideye_frame[NUM_PIXELS];
 	system_init();
+	grideye_init();
 	pir_init(pir_on_wake);  // Init PIR
 
 	while(1) {
+		if (!ge_is_sleeping()) {
+			ge_get_frame(grideye_frame);
+			// TODO: Do something with grideye_frame
+		}
 	}
 }


### PR DESCRIPTION
Currently the pads are not set to be the correct ones because the board pads are messed up. I2C only works on PAD0 (SDA) and PAD1 (SCL) of each SERCOM module.