### PR TITLE
Implemented Lora Sleep/Wake

### DIFF
--- a/occulow-firmware/src/drivers/lora/lora.c
+++ b/occulow-firmware/src/drivers/lora/lora.c
@@ -190,12 +190,18 @@ void lora_join_otaa() {
 	}
 }
 
+/**
+ * @brief      Sleeps the lora module indefinitely
+ */
 void lora_sleep(void) {
 	// Sleep "indefinitely": 24.86 days (INT_MAX ms)
 	uint16_t cmd_length = sprintf((char *) tx_buffer, SLEEP_CMD, 2147483647);
 	while(usart_write_buffer_wait(&lora_usart_module, tx_buffer, cmd_length) != STATUS_OK);
 }
 
+/**
+ * @brief      Wakes up the lora module, assuming that it is asleep
+ */
 void lora_wake(void) {
 	struct usart_config lora_wake_config;
 

--- a/occulow-firmware/src/drivers/lora/lora.h
+++ b/occulow-firmware/src/drivers/lora/lora.h
@@ -32,6 +32,8 @@ void lora_init(void);
 void lora_join_otaa(void);
 void lora_join_abp(void);
 void lora_reset(void);
+void lora_sleep(void);
+void lora_wake(void);
 lora_status_t lora_send_cmd(lora_cmd_t cmd, uint16_t len);
 void lora_send_data(uint8_t *string, uint16_t len);
 void lora_send_count(uint16_t ingress, uint16_t egress);

--- a/occulow-firmware/src/drivers/lora/lora_commands.h
+++ b/occulow-firmware/src/drivers/lora/lora_commands.h
@@ -24,5 +24,6 @@ static const char SET_CHANNEL_STATUS_CMD[] = "mac set ch status %d %s\r\n";
 static const char JOIN_OTAA_CMD[] = "mac join otaa\r\n";
 static const char JOIN_ABP_CMD[] = "mac join abp\r\n";
 static const char SEND_UNCONF_CMD[] = "mac tx uncnf 1 %s\r\n";
+static const char SLEEP_CMD[] = "sys sleep %d\r\n";
 
 #endif /* LORA_COMMANDS_H_ */

--- a/occulow-firmware/src/drivers/lora/lora_commands.h
+++ b/occulow-firmware/src/drivers/lora/lora_commands.h
@@ -10,6 +10,7 @@
 #define LORA_COMMANDS_H_
 
 static const char FACTORY_RESET_CMD[] = "sys factoryRESET\r\n";
+static const char GET_VER[] = "sys get ver\r\n";
 static const char SET_APPEUI_CMD[] = "mac set appeui %s\r\n";
 static const char SET_DEVEUI_CMD[] = "mac set deveui %s\r\n";
 static const char SET_APPKEY_CMD[] = "mac set appkey %s\r\n";
@@ -25,5 +26,6 @@ static const char JOIN_OTAA_CMD[] = "mac join otaa\r\n";
 static const char JOIN_ABP_CMD[] = "mac join abp\r\n";
 static const char SEND_UNCONF_CMD[] = "mac tx uncnf 1 %s\r\n";
 static const char SLEEP_CMD[] = "sys sleep %d\r\n";
+static const char AUTO_BAUD_CMD[] = {0x55, '\r', '\n'}
 
 #endif /* LORA_COMMANDS_H_ */

--- a/occulow-firmware/src/main.c
+++ b/occulow-firmware/src/main.c
@@ -49,6 +49,7 @@ int main (void)
 	pir_init(pir_on_wake);
 
 	lora_join_otaa();
+	lora_sleep();
 
 	double in_count = 0;
 	double out_count = 0;
@@ -60,7 +61,9 @@ int main (void)
 			// Each grideye cycle is ~100ms (since it claims 10FPS), so each tick of the
 			//  inactivity counter is assumed to be 100ms.
 			inactivity_counter = 0;
+			lora_wake();
 			lora_send_count(period_in_count, period_out_count);
+			lora_sleep();
 			period_in_count = 0;
 			period_out_count = 0;
 			ge_set_mode(GE_MODE_SLEEP);


### PR DESCRIPTION
The only strangeness is that the datasheet claims that the RN2903 will send "ok" after waking up, however it also sends "in" for some reason (and it appears to be consistent). I've hacked around that by just reading response a second time.